### PR TITLE
Add support for timeouts in asio/server

### DIFF
--- a/lib/asio/CMakeLists.txt
+++ b/lib/asio/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.7)
 
 project(asio)
 
+LIST(APPEND CMAKE_CXX_FLAGS -std=c++11)
+
 add_subdirectory(client)
 add_subdirectory(server)
 

--- a/lib/include/crete/asio/server.h
+++ b/lib/include/crete/asio/server.h
@@ -7,6 +7,7 @@
 #include <boost/asio.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/filesystem/path.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <crete/asio/common.h>
 
@@ -42,7 +43,7 @@ public:
     template <typename Handler>
     void open_connection_async(Handler handler);
     void open_connection_wait();
-    void open_connection_wait(boost::posix_time::time_duration timeout);
+    bool open_connection_wait(const boost::posix_time::time_duration& timeout);
     bool is_socket_open(); // Will return true even if connection has been closed.
 
     void update_directory(const boost::filesystem::path& from, const boost::filesystem::path& to);
@@ -59,6 +60,7 @@ private:
     boost::asio::ip::tcp::acceptor acceptor_;
     boost::asio::ip::tcp::socket socket_;
     Port port_;
+    boost::asio::deadline_timer deadline_timer_;
 };
 
 template <typename Handler>


### PR DESCRIPTION
This is an addition only. It does not change any existing functionality.
Server::open_connection_wait() is given an overload that takes a time
duration. The connection attempt will abort if not made within the given
time.